### PR TITLE
Add style to blockquote to match steemit and busy

### DIFF
--- a/contents/styles/main.styl
+++ b/contents/styles/main.styl
@@ -45,6 +45,12 @@ a
     color: accent-color
   &:hover
     text-decoration: underline
+    
+blockquote
+  margin-left: 1rem
+  padding: .4rem
+  border-left: 1px solid rgba(0,0,0,.6)
+  color: rgba(0,0,0,.6)
 
 #no-js
   display: none


### PR DESCRIPTION
I noticed when using quotes you could clearly tell it was one on Steemit and Busy but not on selfsteem.

I've updated my stylesheet based on what Busy does so I thought I'd post the suggestion here.

Example of style:

![screenshot from 2018-09-03 15-58-31](https://user-images.githubusercontent.com/9503662/45000436-d6e1ac00-af92-11e8-8dc6-ad9b5052f708.png)
